### PR TITLE
Proper handle case s.last.Len() < len(buf)

### DIFF
--- a/cmd/remote-archive-ls/main.go
+++ b/cmd/remote-archive-ls/main.go
@@ -12,16 +12,52 @@ import (
 	"github.com/jeffallen/seekinghttp"
 )
 
+const (
+	LevelDebug int = -4
+	LevelInfo  int = 0
+)
+
+// CustomLogger is a custom implementation of the Logger interface
+type CustomLogger struct {
+	Level int
+}
+
+// Infof logs an informational message
+func (l CustomLogger) Infof(format string, args ...interface{}) {
+	if l.Level <= LevelInfo {
+		log.Printf(fmt.Sprintf("[INFO] %s", format), args...)
+	}
+}
+
+// Debugf logs a debug message
+func (l CustomLogger) Debugf(format string, args ...interface{}) {
+	if l.Level <= LevelDebug {
+		log.Printf(fmt.Sprintf("[DEBUG] %s", format), args...)
+	}
+}
+
+func (l CustomLogger) Fatal(args ...interface{}) {
+	log.Fatal(args...)
+}
+
 var debug = flag.Bool("debug", false, "enable verbose output")
 
 func main() {
 	flag.Parse()
+
+	level := LevelInfo
+	if *debug {
+		level = LevelDebug
+	}
+
+	logger := &CustomLogger{Level: level}
+
 	if flag.NArg() == 0 {
-		log.Fatal("Expected a URL as the first argument.")
+		logger.Fatal("Expected a URL as the first argument.")
 	}
 
 	r := seekinghttp.New(flag.Arg(0))
-	r.Debug = *debug
+	r.SetLogger(logger)
 
 	if strings.HasSuffix(flag.Arg(0), ".tar") {
 		t := tar.NewReader(r)
@@ -31,9 +67,9 @@ func main() {
 				break
 			}
 			if err != nil {
-				log.Fatal(err)
+				logger.Fatal(err)
 			}
-			fmt.Println("File:", h.Name)
+			logger.Infof("File: %s", h.Name)
 		}
 		return
 	}
@@ -41,19 +77,19 @@ func main() {
 	if strings.HasSuffix(flag.Arg(0), ".zip") {
 		sz, err := r.Size()
 		if err != nil {
-			log.Fatal(err)
+			logger.Fatal(err)
 		}
 
 		z, err := zip.NewReader(r, sz)
 		if err != nil {
-			log.Fatal(err)
+			logger.Fatal(err)
 		}
 
 		for _, f := range z.File {
-			log.Print("File: ", f.FileHeader.Name)
+			logger.Infof("File: %s", f.FileHeader.Name)
 		}
 		return
 	}
 
-	log.Fatal("Unknown file type. URL does not end in .tar or .zip")
+	logger.Fatal("Unknown file type. URL does not end in .tar or .zip")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/jeffallen/seekinghttp
+
+go 1.18
+
+require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/seekinghttp.go
+++ b/seekinghttp.go
@@ -145,7 +145,8 @@ func (s *SeekingHTTP) ReadAt(buf []byte, off int64) (int, error) {
 		if err == io.EOF && n == len(buf) {
 			err = nil
 		}
-		return len(buf), err
+
+		return n, err
 	}
 	return 0, io.EOF
 }

--- a/seekinghttp.go
+++ b/seekinghttp.go
@@ -178,11 +178,11 @@ func (s *SeekingHTTP) Seek(offset int64, whence int) (int64, error) {
 		log.Printf("got seek %v %v", offset, whence)
 	}
 	switch whence {
-	case os.SEEK_SET:
+	case io.SeekStart:
 		s.offset = offset
-	case os.SEEK_CUR:
+	case io.SeekCurrent:
 		s.offset += offset
-	case os.SEEK_END:
+	case io.SeekEnd:
 		return 0, errors.New("whence relative to end not impl yet")
 	default:
 		return 0, os.ErrInvalid

--- a/seekinghttp_test.go
+++ b/seekinghttp_test.go
@@ -1,0 +1,48 @@
+package seekinghttp
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// MockHTTPClient is a mock implementation of the http.Client interface for testing purposes.
+type MockHTTPClient struct{}
+
+func (c *MockHTTPClient) Do(_ *http.Request) (*http.Response, error) {
+	// Create a mock response for testing purposes.
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader([]byte("Mock HTTP response body"))),
+	}
+	return resp, nil
+}
+
+func TestReadAt(t *testing.T) {
+	// Create a new SeekingHTTP instance with a mock HTTP client.
+	s := New("https://example.com")
+	s.Client = &MockHTTPClient{}
+
+	// Define test cases.
+	testCases := []struct {
+		offset    int64
+		bufSize   int
+		expectLen int
+		expectErr error
+	}{
+		{0, 10, 10, nil},
+		{10, 1, 1, nil},
+		{30, 30, 23, nil},
+	}
+
+	for _, tc := range testCases {
+		buf := make([]byte, tc.bufSize)
+		n, err := s.ReadAt(buf, tc.offset)
+
+		assert.ErrorIs(t, err, tc.expectErr, "ReadAt(offset=%d, bufSize=%d) error = %v, expected error = %v", tc.offset, tc.bufSize, err, tc.expectErr)
+		assert.Equal(t, n, tc.expectLen, "ReadAt(offset=%d, bufSize=%d) len = %d, expected len = %d", tc.offset, tc.bufSize, n, tc.expectLen)
+	}
+}


### PR DESCRIPTION
Return the number of bytes that have been read on last request

## Context ##
we are've using this library together with `github.com/biogo/hts/bgzf`

like 
```
httpReader := seekinghttp.New("https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/vcf/exomes/gnomad.exomes.r2.1.1.sites.6.vcf.bgz")
vcfReader, err := bgzf.NewReader(httpReader, 4)
```

the call where it requests the last 28 bytes of the file. SeekingHTTP.ReadAt is called with an output buffer buf with length 4096. It makes an HTTP request for 4096 bytes, starting 28 bytes from the end, and gets a 28 byte response, as it should. It copies those 28 bytes into the output buffer on line 137, correctly. But then on line 148 it returns len(buf), which is 4096, for the number of bytes it read into the buffer. It should actually be returning n, which is 28. 

so we've got error: gzip: invalid header
because of it